### PR TITLE
Fix extension setup and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,25 @@
 
 
-This repository contains a React Native application and a Chrome extension.
+This repository contains a small Chrome extension that automatically removes
+cookie consent banners from webpages.
 
 ## Setup in the Codex environment
 
-Run the provided setup script to install dependencies before network access is disabled:
+Run the provided setup script to install dependencies (if any) before network
+access is disabled:
 
 ```bash
 ./codex-setup.sh
 ```
 
-This installs the Node.js dependencies listed in `package.json` if they are not already present.
+The script installs the Node.js dependencies listed in `package.json` when such a
+file exists. If no `package.json` is present (as is the case for this simple
+extension) the installation step is skipped.
+
+### Loading the extension
+
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this directory.
+4. The extension's popup allows you to manually trigger the cookie banner
+   removal on the active tab.

--- a/codex-setup.sh
+++ b/codex-setup.sh
@@ -4,11 +4,15 @@
 set -e
 
 # Install npm dependencies only if node_modules is missing or outdated
-if [ ! -d node_modules ]; then
-  echo "Installing npm dependencies..."
-  npm install
+if [ -f package.json ]; then
+  if [ ! -d node_modules ]; then
+    echo "Installing npm dependencies..."
+    npm install
+  else
+    echo "node_modules already exists, skipping npm install"
+  fi
 else
-  echo "node_modules already exists, skipping npm install"
+  echo "No package.json found, skipping npm install"
 fi
 
 # Additional setup steps for the Chrome extension can be added here

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
       "default_popup": "popup.html",
       "default_title": "Cookie Killer"
     },
-    "permissions": ["storage"],
+    "permissions": ["storage", "tabs", "scripting"],
     "host_permissions": ["<all_urls>"],
     "content_scripts": [
       {


### PR DESCRIPTION
## Summary
- add required Chrome permissions
- guard against missing package.json in setup script
- clarify readme instructions for the extension

## Testing
- `bash ./codex-setup.sh`
- `node --check content.js`

------
https://chatgpt.com/codex/tasks/task_b_683f4e44c0c48322974de9914e14a414